### PR TITLE
Remove dependency on project ENV variables for connection info

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,26 @@ Then run `bundle`!
 
 ## Using in a project
 
-Once the gem is installed in your project and the environment is set up, you can start posting statements! There are two functions you can use for this, and they both take an xAPI statement hash as a parameter:
+Once the gem is installed in your project, you can start posting statements! There are two functions you can use for this, and they both take hashes of connection information and an xAPI statement as parameters.
 
 For asynchronous statement posting, if you're working with `sidekiq` (recommended):
 
 ```ruby
-LearningLinker::PostStatementWorker.perform_async(<endpoint_url>, <basic_auth_token>, <statement>)
+LearningLinker::PostStatementWorker.perform_async(<connection>, <statement>)
 ```
 
 If `sidekiq` is not a part of your project, you can post the statement synchronously with:
 
 ```ruby
-LearningLinker::StatementHandler.post_statement(<endpoint_url>, <basic_auth_token>, <statement>)
+LearningLinker::StatementHandler.post_statement(<connection>, <statement>)
 ```
+
+## Connection hash
+
+ The connection hash expected by LearningLinker requires two properties, both relating to values you can find in your LearningLocker instance's "client" section:
+
+ - `xapi_url` - xAPI Endpoint. Example: `https://locker.example.com/data/xAPI`
+ - `basic_auth` - Basic auth token string, with "Basic " prepended. Example: `Basic OWY3YmRmNzkxZjBkMjA5MzBmM2JlMGVkYTQ1Y2E0OTZhYjExampleToyMmU3OGQ3YjQ5MGJhYWRlNTg5NTgwNzg5ZTA1ZjRkOTQ3YjRkMDg5`
 
 ### Statement constants
 
@@ -65,8 +72,10 @@ To put it all together, here's an example call that might be made when a student
 
 ```ruby
   LearningLinker::PostStatementWorker.perform_async(
-    <endpoint_url>,
-    <auth_token>,
+    {
+      xapi_url: "https://locker.example.com/data/xAPI"
+      basic_auth: "Basic OWY3YmRmNzkxZjBkMjA5MzBmM2JlMGVkYTQ1Y2E0OTZhYjExampleToyMmU3OGQ3YjQ5MGJhYWRlNTg5NTgwNzg5ZTA1ZjRkOTQ3YjRkMDg5"
+    },
     {
       actor:   {
         name:       @student.name,

--- a/README.md
+++ b/README.md
@@ -10,14 +10,6 @@ To add this gem to your Rails project, add the following line to your gemfile, u
 
 Then run `bundle`!
 
-### Environment Variables
-
-Ensure your Rails environment has the following environment variables:
-
-| `LRS_XAPI_URL`  | URL leading to the xAPI endpoint of your LearningLocker LRS |
-| --------------- | ----------------------------------------------------------- |
-| `LRS_XAPI_AUTH` | Basic Authorization token for the LearningLocker instance   |
-
 ## Using in a project
 
 Once the gem is installed in your project and the environment is set up, you can start posting statements! There are two functions you can use for this, and they both take an xAPI statement hash as a parameter:
@@ -25,13 +17,13 @@ Once the gem is installed in your project and the environment is set up, you can
 For asynchronous statement posting, if you're working with `sidekiq` (recommended):
 
 ```ruby
-LearningLinker::PostStatementWorker.perform_async(...)
+LearningLinker::PostStatementWorker.perform_async(<endpoint_url>, <basic_auth_token>, <statement>)
 ```
 
 If `sidekiq` is not a part of your project, you can post the statement synchronously with:
 
 ```ruby
-LearningLinker::StatementHandler.post_statement(...)
+LearningLinker::StatementHandler.post_statement(<endpoint_url>, <basic_auth_token>, <statement>)
 ```
 
 ### Statement constants
@@ -72,7 +64,10 @@ While you're free to form a complete custom statement from scratch, this gem als
 To put it all together, here's an example call that might be made when a student (`@student`) views an activity (`@activity`):
 
 ```ruby
-  LearningLinker::PostStatementWorker.perform_async({
+  LearningLinker::PostStatementWorker.perform_async(
+    <endpoint_url>,
+    <auth_token>,
+    {
       actor:   {
         name:       @student.name,
         mbox:       "mailto:#{@student.email}",

--- a/learning-linker.gemspec
+++ b/learning-linker.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |spec|
   spec.name = 'learning-linker'
   spec.summary = 'Statement logger for LearningLocker LRS'
-  spec.version = '0.1.3'
+  spec.version = '0.2.0-test'
   spec.author = ['Lighthouse Labs', 'Quinn Branscombe']
   spec.files = ['lib/learning-linker.rb']
   spec.require_paths = ['lib']

--- a/lib/learning-linker.rb
+++ b/lib/learning-linker.rb
@@ -130,8 +130,8 @@ module LearningLinker
 
     sidekiq_options retry: false
 
-    def perform(endpoint, auth_token, statement)
-      StatementHandler.post_statement(endpoint, auth_token, statement)
+    def perform(connection, statement)
+      StatementHandler.post_statement(connection, statement)
     end
   end
 end

--- a/lib/learning-linker.rb
+++ b/lib/learning-linker.rb
@@ -105,15 +105,15 @@ module LearningLinker
   # Class for creating statements and posting them to LearningLocker LRS
   class StatementHandler
     # Send a statement to the LRS via HTTP
-    def self.post_statement(endpoint, auth_token, statement)
-      unless endpoint && auth_token
-        puts 'Warning: LRS not configured! No statement was sent.'
+    def self.post_statement(connection, statement)
+      unless connection && connection[:xapi_url] && connection[:basic_auth]
+        puts 'Warning: Connection info missing or incomplete! No statement was sent.'
         return
       end
 
-      response = HTTParty.post("#{endpoint}/statements", {
+      response = HTTParty.post("#{connection[:xapi_url]}/statements", {
                                  body: statement.to_json,
-                                 headers: { 'Authorization': auth_token.to_s,
+                                 headers: { 'Authorization': connection[:basic_auth].to_s,
                                             'X-Experience-API-Version': '1.0.3',
                                             'Content-Type': 'application/json' }
                                })

--- a/lib/learning-linker.rb
+++ b/lib/learning-linker.rb
@@ -105,15 +105,15 @@ module LearningLinker
   # Class for creating statements and posting them to LearningLocker LRS
   class StatementHandler
     # Send a statement to the LRS via HTTP
-    def self.post_statement(statement)
-      unless ENV['LRS_XAPI_URL'] && ENV['LRS_XAPI_AUTH']
+    def self.post_statement(endpoint, auth_token, statement)
+      unless endpoint && auth_token
         puts 'Warning: LRS not configured! No statement was sent.'
         return
       end
 
-      response = HTTParty.post("#{ENV['LRS_XAPI_URL']}/statements", {
+      response = HTTParty.post("#{endpoint}/statements", {
                                  body: statement.to_json,
-                                 headers: { 'Authorization': "Basic #{ENV['LRS_XAPI_AUTH']}",
+                                 headers: { 'Authorization': auth_token.to_s,
                                             'X-Experience-API-Version': '1.0.3',
                                             'Content-Type': 'application/json' }
                                })
@@ -130,8 +130,8 @@ module LearningLinker
 
     sidekiq_options retry: false
 
-    def perform(statement)
-      StatementHandler.post_statement(statement)
+    def perform(endpoint, auth_token, statement)
+      StatementHandler.post_statement(endpoint, auth_token, statement)
     end
   end
 end

--- a/lib/learning-linker.rb
+++ b/lib/learning-linker.rb
@@ -106,14 +106,14 @@ module LearningLinker
   class StatementHandler
     # Send a statement to the LRS via HTTP
     def self.post_statement(connection, statement)
-      unless connection && connection[:xapi_url] && connection[:basic_auth]
+      unless connection && connection['xapi_url'] && connection['basic_auth']
         puts 'Warning: Connection info missing or incomplete! No statement was sent.'
         return
       end
 
-      response = HTTParty.post("#{connection[:xapi_url]}/statements", {
+      response = HTTParty.post("#{connection['xapi_url']}/statements", {
                                  body: statement.to_json,
-                                 headers: { 'Authorization': connection[:basic_auth].to_s,
+                                 headers: { 'Authorization': connection['basic_auth'].to_s,
                                             'X-Experience-API-Version': '1.0.3',
                                             'Content-Type': 'application/json' }
                                })


### PR DESCRIPTION
## Change Summary

Instead of having LearningLinker directly access ENV variables from the projects it's used in, make each call to post a statement take connection info (xAPI endpoint and basic auth) as a hash instead.

In theory, because the connection hash expects `xapi_url` and `basic_auth` as properties, one could pass a serialized `XStore` record from Compass into it.