### PR TITLE
Remove built-in sidekiq worker

### DIFF
--- a/learning-linker.gemspec
+++ b/learning-linker.gemspec
@@ -3,10 +3,9 @@
 Gem::Specification.new do |spec|
   spec.name = 'learning-linker'
   spec.summary = 'Statement logger for LearningLocker LRS'
-  spec.version = '0.2.1'
+  spec.version = '0.3.0'
   spec.author = ['Lighthouse Labs', 'Quinn Branscombe']
   spec.files = ['lib/learning-linker.rb']
   spec.require_paths = ['lib']
   spec.add_dependency 'httparty'
-  spec.add_dependency 'sidekiq'
 end

--- a/lib/learning-linker.rb
+++ b/lib/learning-linker.rb
@@ -188,17 +188,4 @@ module LearningLinker
       end
     end
   end
-
-  # Sidekiq worker for posting statements in the background
-  # Perhaps not the best implementation, since apps using this gem could easily spin up their own worker with their own settings. Convenient for us for now though
-  # If we remove this at any point, we can also remove the sidekiq dep -Q
-  class PostStatementWorker
-    include Sidekiq::Worker
-
-    sidekiq_options retry: 5
-
-    def perform(connection, statement)
-      StatementHandler.post_statement(connection, statement)
-    end
-  end
 end


### PR DESCRIPTION
This PR removes the built-in sidekiq worker, `PostStatementWorker`, and adds instructions for easily creating your own worker in `sidekiq`-enabled projects.

- Removes the dependency on `sidekiq`
- Bumps version to `0.3.0` because it will be incompatible with projects that may have relied on `PostStatementWorker`